### PR TITLE
ejs formatter settigns vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "emmet.includeLanguages": {
+      "ejs": "html",
+    },
+   "[html]": {
+      "editor.defaultFormatter": "j69.ejs-beautify"
+    },
 }


### PR DESCRIPTION
overtime this will help improve the ejs formatting. may have to manually do some formatting, but now prettier should not automatically move things into weird positions.