### PR TITLE
Add FRC Radio resource entry, dashboard sidebar link, and landing page

### DIFF
--- a/dist/routes/public.js
+++ b/dist/routes/public.js
@@ -42,6 +42,14 @@ router.get("/resources", (req, res, next) => {
         next(err);
     }
 });
+router.get("/radio", (req, res, next) => {
+    try {
+        res.render("radio", { auth: req.session.user });
+    }
+    catch (err) {
+        next(err);
+    }
+});
 router.get("/vtt-guide", (req, res, next) => {
     try {
         res.render("vtt-guide", { auth: req.session.user });

--- a/public/css/components/dashboard.css
+++ b/public/css/components/dashboard.css
@@ -865,6 +865,117 @@
 }
 
 /* ==========================================================================
+   Radio Card (Sidebar)
+   ========================================================================== */
+
+.radio-card {
+  background: linear-gradient(155deg,
+      var(--surface-1) 0%,
+      rgba(43, 64, 83, 0.45) 50%,
+      rgba(73, 42, 87, 0.08) 100%);
+  border-color: var(--border-ornate);
+}
+
+.radio-card::before {
+  background: linear-gradient(90deg,
+      transparent 0%,
+      var(--purple) 25%,
+      var(--blue6) 50%,
+      var(--purple) 75%,
+      transparent 100%);
+  opacity: 0.35;
+  animation: softPulse 5s ease-in-out infinite;
+}
+
+.radio-link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--border-radius);
+  border: 1px solid var(--border-ornate);
+  background: linear-gradient(135deg,
+      rgba(73, 42, 87, 0.08) 0%,
+      rgba(116, 167, 215, 0.04) 50%,
+      rgba(73, 42, 87, 0.1) 100%);
+  color: var(--blue6);
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+  text-decoration: none;
+  position: relative;
+  overflow: hidden;
+  transition:
+    border-color var(--transition-smooth),
+    background var(--transition-smooth),
+    box-shadow var(--transition-smooth),
+    color var(--transition-smooth);
+}
+
+.radio-link::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg,
+      transparent 0%,
+      rgba(116, 167, 215, 0.06) 40%,
+      rgba(150, 120, 200, 0.1) 50%,
+      rgba(116, 167, 215, 0.06) 60%,
+      transparent 100%);
+  transition: left 0.6s ease;
+  pointer-events: none;
+}
+
+.radio-link:hover::after {
+  left: 100%;
+}
+
+.radio-link:hover {
+  border-color: var(--border-ornate-hover);
+  background: linear-gradient(135deg,
+      rgba(73, 42, 87, 0.12) 0%,
+      rgba(116, 167, 215, 0.07) 50%,
+      rgba(73, 42, 87, 0.14) 100%);
+  box-shadow:
+    0 0 16px rgba(116, 167, 215, 0.08),
+    inset 0 0 20px rgba(116, 167, 215, 0.03);
+  color: var(--bright-white);
+}
+
+.radio-link:active {
+  transform: scale(0.98);
+}
+
+.radio-link-text {
+  flex: 1;
+}
+
+.radio-link-icon {
+  display: flex;
+  align-items: center;
+  color: var(--purple);
+  transition: color var(--transition-normal);
+}
+
+.radio-link:hover .radio-link-icon {
+  color: var(--blue6);
+}
+
+.radio-link-arrow {
+  font-size: 1.1rem;
+  transition: transform var(--transition-smooth);
+  line-height: 1;
+}
+
+.radio-link:hover .radio-link-arrow {
+  transform: translateX(3px);
+}
+
+/* ==========================================================================
    Modal Form Styles
    ========================================================================== */
 

--- a/public/css/features/radio.css
+++ b/public/css/features/radio.css
@@ -1,0 +1,134 @@
+/* ==========================================================================
+   FRC Radio Landing Page
+   ========================================================================== */
+
+/* ===== Hero ===== */
+.radio-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 2.5rem 1rem 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.radio-hero-icon {
+  margin-bottom: 1.25rem;
+  animation: radioFloat 6s ease-in-out infinite;
+}
+
+.radio-hero h1 {
+  font-size: 3rem;
+  background: linear-gradient(135deg, var(--orange3) 0%, var(--orange2) 40%, var(--blue6) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.radio-hero-tagline {
+  color: var(--light-gray);
+  font-size: 1.15rem;
+  max-width: 500px;
+  line-height: 1.6;
+}
+
+.radio-hero hr {
+  width: 150px;
+  height: 4px;
+  background: linear-gradient(90deg, var(--orange), var(--blue6), var(--purple));
+  border: none;
+  margin: 1.25rem auto;
+  border-radius: 2px;
+}
+
+/* ===== CTA Button ===== */
+.radio-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 28px;
+  background: linear-gradient(135deg, var(--blue) 0%, var(--blue4) 100%);
+  border: 1px solid var(--blue2);
+  border-radius: 8px;
+  color: var(--bright-white);
+  font-size: 1.05rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.radio-cta:hover {
+  background: linear-gradient(135deg, var(--blue2) 0%, var(--blue) 100%);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+}
+
+.radio-cta:active {
+  transform: translateY(0);
+}
+
+/* ===== Bottom CTA ===== */
+.radio-bottom-cta {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  margin: 1rem 0;
+}
+
+.radio-bottom-cta p {
+  color: var(--light-gray);
+  font-size: 1.15rem;
+  margin-bottom: 1rem;
+}
+
+/* ===== Sound Wave Animations ===== */
+.radio-wave {
+  animation: radioPulse 2.5s ease-in-out infinite;
+  transform-origin: center;
+}
+
+.radio-wave-1 {
+  animation-delay: 0s;
+}
+
+.radio-wave-2 {
+  animation-delay: 0.4s;
+}
+
+.radio-wave-3 {
+  animation-delay: 0.8s;
+}
+
+@keyframes radioPulse {
+  0%, 100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes radioFloat {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 600px) {
+  .radio-hero h1 {
+    font-size: 2.2rem;
+  }
+
+  .radio-hero-tagline {
+    font-size: 1rem;
+  }
+
+  .radio-cta {
+    padding: 10px 22px;
+    font-size: 0.95rem;
+  }
+}

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -42,6 +42,14 @@ router.get("/resources", (req: Request, res: Response, next: NextFunction) => {
   }
 });
 
+router.get("/radio", (req: Request, res: Response, next: NextFunction) => {
+  try {
+    res.render("radio", { auth: req.session.user });
+  } catch (err) {
+    next(err);
+  }
+});
+
 router.get("/vtt-guide", (req: Request, res: Response, next: NextFunction) => {
   try {
     res.render("vtt-guide", { auth: req.session.user });

--- a/views/dash.ejs
+++ b/views/dash.ejs
@@ -39,6 +39,19 @@
           <span class="library-link-arrow">&rarr;</span>
         </a>
       </div>
+      <div class="dashboard-sidebar-card dashboard-sidebar-card-spaced radio-card">
+        <div class="dashboard-sidebar-title">FRC Radio</div>
+        <small>Stream background music for your tabletop sessions.</small>
+        <a class="radio-link" href="https://radio.farreachco.com" target="_blank" rel="noopener">
+          <span class="radio-link-text">Host a Channel</span>
+          <span class="radio-link-icon">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+              <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
+            </svg>
+          </span>
+          <span class="radio-link-arrow">&rarr;</span>
+        </a>
+      </div>
     </aside>
     <main class="dashboard-main">
       <% if (section === 'overview') { %>

--- a/views/radio.ejs
+++ b/views/radio.ejs
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FRC Radio - On-Demand Music for Tabletop Sessions | Far Reach Co.</title>
+  <meta name="description" content="FRC Radio streams curated background music for your D&D and tabletop RPG sessions. Create a channel, pick a playlist, share the link. Everyone listens in sync from any browser." />
+  <meta name="keywords" content="FRC Radio, D&D music, tabletop music, RPG background music, session music streaming, DM tools, ambient music, combat music" />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://farreachco.com/radio" />
+  <meta property="og:title" content="FRC Radio - On-Demand Music for Tabletop Sessions" />
+  <meta property="og:description" content="Stream curated background music for your D&D and tabletop RPG sessions. The DM controls the vibe. Everyone listens in sync." />
+  <meta property="og:site_name" content="Far Reach Co." />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="FRC Radio - On-Demand Music Streaming for Tabletop RPGs" />
+  <meta name="twitter:description" content="Stream curated background music for your D&D and tabletop RPG sessions. The DM controls the vibe. Everyone listens in sync." />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebApplication",
+      "name": "FRC Radio",
+      "description": "On-demand music streaming for tabletop RPG sessions with curated playlists for combat, exploration, taverns, and more",
+      "url": "https://radio.farreachco.com",
+      "applicationCategory": "MultimediaApplication",
+      "operatingSystem": "Web Browser",
+      "offers": [{
+        "@type": "Offer",
+        "name": "Free",
+        "price": "0",
+        "priceCurrency": "USD",
+        "description": "Standard playlist library access"
+      }, {
+        "@type": "Offer",
+        "name": "Pro",
+        "description": "Full playlist catalog including exclusive pro playlists"
+      }],
+      "creator": {
+        "@type": "Organization",
+        "name": "Far Reach Co.",
+        "url": "https://farreachco.com"
+      }
+    }
+  </script>
+
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/css/features/info.css" />
+  <link rel="stylesheet" href="/css/features/radio.css" />
+  <script src="/lib/MobileNavHandler.js" defer></script>
+  <%- include('./partials/icons') %>
+</head>
+<%- include('./partials/google') %>
+
+<body>
+  <%- include('./partials/nav') %>
+  <div class="container-fluid p-3 info-container">
+
+    <!-- Hero Section -->
+    <div class="radio-hero">
+      <div class="radio-hero-icon">
+        <svg viewBox="0 0 80 80" width="80" height="80" fill="none">
+          <circle cx="40" cy="40" r="36" stroke="var(--orange2)" stroke-width="1.5" opacity="0.25"/>
+          <circle cx="40" cy="40" r="26" stroke="var(--blue6)" stroke-width="1" opacity="0.35"/>
+          <circle cx="40" cy="40" r="16" stroke="var(--orange3)" stroke-width="1.5" opacity="0.5"/>
+          <circle cx="40" cy="40" r="5" fill="var(--orange2)"/>
+          <!-- Sound waves -->
+          <path d="M52 28a18 18 0 0 1 0 24" stroke="var(--orange3)" stroke-width="2" stroke-linecap="round" class="radio-wave radio-wave-1"/>
+          <path d="M56 22a26 26 0 0 1 0 36" stroke="var(--blue6)" stroke-width="1.5" stroke-linecap="round" class="radio-wave radio-wave-2"/>
+          <path d="M60 16a34 34 0 0 1 0 48" stroke="var(--orange2)" stroke-width="1" stroke-linecap="round" class="radio-wave radio-wave-3"/>
+        </svg>
+      </div>
+      <h1>FRC Radio</h1>
+      <p class="radio-hero-tagline">On-demand music streaming for your tabletop sessions</p>
+      <hr>
+      <a href="https://radio.farreachco.com" target="_blank" rel="noopener" class="radio-cta">
+        <span>Open FRC Radio</span>
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3" />
+        </svg>
+      </a>
+    </div>
+
+    <!-- Quick Links -->
+    <div class="quick-links">
+      <a href="#what-is-it">What Is It</a>
+      <a href="#how-it-works">How It Works</a>
+      <a href="#playlists">Playlists</a>
+      <a href="#hosting">Hosting</a>
+      <a href="#listening">Listening</a>
+      <a href="#pro">Pro Features</a>
+      <a href="#faq">FAQ</a>
+    </div>
+
+    <!-- What Is It -->
+    <section id="what-is-it">
+      <h2>What Is FRC Radio?</h2>
+      <p>
+        FRC Radio is a music streaming service built specifically for tabletop RPG groups. It lets the Dungeon Master (or any host) stream curated background music to their entire group in real time. No downloads, no installs, no complicated setup - just a browser.
+      </p>
+      <p>
+        Think of it like having your own personal radio station for game night. You pick the playlist, your players open a link, and everyone hears the same music at the same time. Transition from a peaceful tavern scene to an intense dragon fight with a single button press.
+      </p>
+      <p>
+        The music library features original compositions and curated tracks organized into playlists designed for specific RPG scenarios - combat encounters, dungeon exploration, town visits, eerie horror sequences, triumphant victories, and more.
+      </p>
+    </section>
+
+    <!-- How It Works -->
+    <section id="how-it-works">
+      <h2>How It Works</h2>
+      <p>FRC Radio is designed to be as simple as possible so you can spend more time playing and less time fiddling with tech.</p>
+
+      <h3>1. Create a Channel</h3>
+      <p>
+        Head to <a href="https://radio.farreachco.com" target="_blank" rel="noopener">radio.farreachco.com</a> and enter a channel name. Channel names can include letters, numbers, hyphens, and underscores. This opens your <strong>Host Control Panel</strong>.
+      </p>
+
+      <h3>2. Pick a Playlist</h3>
+      <p>
+        From the host panel, browse the available playlists and select one. Music starts streaming immediately. You can switch playlists at any time during your session - perfect for matching the mood to what's happening in the game.
+      </p>
+
+      <h3>3. Share the Listener Link</h3>
+      <p>
+        The host panel gives you a shareable listener URL. Send it to your players via Discord, text, email, or however you communicate. They click the link, hit play, and they're connected.
+      </p>
+
+      <h3>4. Control the Vibe</h3>
+      <p>
+        As the host, you have full control. Switch playlists to match the scene, skip tracks, or stop playback entirely. The host panel shows you what's currently playing and the active playlist at all times.
+      </p>
+    </section>
+
+    <!-- Playlists -->
+    <section id="playlists">
+      <h2>The Music</h2>
+      <p>
+        FRC Radio's library is organized into named playlists, each curated for a specific type of tabletop RPG scenario. Playlists cycle through their tracks automatically, so you never have to worry about silence mid-session.
+      </p>
+      <p>
+        The playlist catalog includes music for a wide range of moods and scenes:
+      </p>
+      <ul>
+        <li><strong>Combat & Battle</strong> - Intense, high-energy tracks for fights and encounters</li>
+        <li><strong>Exploration & Travel</strong> - Sweeping, adventurous music for overworld and dungeon exploration</li>
+        <li><strong>Tavern & Town</strong> - Warm, lively tunes for social encounters and downtime</li>
+        <li><strong>Horror & Suspense</strong> - Dark, unsettling ambience for tense or creepy scenarios</li>
+        <li><strong>Mystery & Intrigue</strong> - Subtle, layered compositions for investigation scenes</li>
+        <li><strong>Triumph & Celebration</strong> - Grand, uplifting music for victories and story milestones</li>
+        <li><strong>Ambient & Atmospheric</strong> - Texture-heavy soundscapes for immersive background</li>
+      </ul>
+      <p>
+        Tracks are sourced from original compositions and curated selections, all delivered via high-quality MP3 streaming through CloudFront CDN for low-latency playback.
+      </p>
+    </section>
+
+    <!-- Hosting a Channel -->
+    <section id="hosting">
+      <h2>Hosting a Channel</h2>
+      <p>
+        Hosting requires a free <a href="https://farreachco.com/register">Far Reach Co. account</a>. You must be logged in before creating a channel. Once authenticated, you can create as many channels as you need.
+      </p>
+
+      <h3>Host Controls</h3>
+      <p>As a host, your control panel provides:</p>
+      <ul>
+        <li><strong>Playlist selector</strong> - Browse and switch between all available playlists</li>
+        <li><strong>Now playing display</strong> - See the current track name, album, and active playlist</li>
+        <li><strong>Listener link</strong> - One-click copy of the shareable URL for your players</li>
+        <li><strong>Playback controls</strong> - Skip tracks or stop the stream</li>
+      </ul>
+
+      <h3>Channel Behavior</h3>
+      <p>
+        Each channel is an independent stream. When you select a playlist, the server begins streaming tracks from that playlist in order. If no listeners connect for 10 minutes, the stream goes idle to save resources and will restart when a listener reconnects.
+      </p>
+    </section>
+
+    <!-- Listening -->
+    <section id="listening">
+      <h2>Listening</h2>
+      <p>
+        Listeners don't need an account. They just need the listener link from the host. Open it in any modern browser, click the play button, and the stream begins.
+      </p>
+      <ul>
+        <li>Works on desktop, tablet, and mobile browsers</li>
+        <li>Volume control built into the player</li>
+        <li>Now Playing display shows the current track and album</li>
+        <li>No software installation required - pure browser-based streaming</li>
+      </ul>
+      <p>
+        Because the stream is server-side, all listeners hear roughly the same point in the music. There's no sync button to press and no drift over time. If a listener joins late, they simply pick up wherever the current track is.
+      </p>
+    </section>
+
+    <!-- Pro Features -->
+    <section id="pro">
+      <h2>Pro Features</h2>
+      <p>
+        FRC Radio works on a free account with access to the standard playlist library. If you subscribe to <strong>Pro on Far Reach Co.</strong>, you unlock the full catalog of exclusive playlists.
+      </p>
+      <ul>
+        <li><strong>Standard (Free)</strong> - Full access to the core playlist library with a variety of moods and scenes</li>
+        <li><strong>Pro</strong> - Everything in Standard, plus exclusive playlists with additional tracks, deeper genre coverage, and premium compositions</li>
+      </ul>
+      <p>
+        Pro playlists are seamlessly integrated - they appear in the same playlist selector alongside the standard library when you're logged in with a Pro account.
+      </p>
+    </section>
+
+    <!-- FAQ -->
+    <section id="faq">
+      <h2>Frequently Asked Questions</h2>
+
+      <h3>Do my players need an account?</h3>
+      <p>No. Only the host needs an account. Listeners can tune in with just the link.</p>
+
+      <h3>Can I use this for in-person games?</h3>
+      <p>Absolutely. Open the listener link on a speaker-connected device and use the host panel on your phone or laptop. It works great for both online and in-person sessions.</p>
+
+      <h3>What audio formats are supported?</h3>
+      <p>The server supports MP3, WAV, OGG, and FLAC files - anything FFmpeg can handle. All audio is transcoded to MP3 for streaming.</p>
+
+      <h3>Does the music keep playing if I close the host panel?</h3>
+      <p>Yes. Once a playlist is started, the server continues streaming. The stream stays active as long as listeners are connected. It goes idle after 10 minutes with no listeners.</p>
+
+      <h3>Can multiple people host on the same channel?</h3>
+      <p>Any logged-in user can send commands to a channel. So if another DM needs to take over music duties, they can open the host panel for the same channel name.</p>
+
+      <h3>Is there a limit to how many listeners can join?</h3>
+      <p>There is no hard listener cap. The stream is designed to handle multiple concurrent listeners per channel.</p>
+    </section>
+
+    <!-- Bottom CTA -->
+    <div class="radio-bottom-cta">
+      <p>Ready to set the mood for your next session?</p>
+      <a href="https://radio.farreachco.com" target="_blank" rel="noopener" class="radio-cta">
+        <span>Open FRC Radio</span>
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3" />
+        </svg>
+      </a>
+    </div>
+
+  </div>
+  <%- include('./partials/footer') %>
+</body>
+
+</html>

--- a/views/resources.ejs
+++ b/views/resources.ejs
@@ -37,6 +37,11 @@
             "description": "Complete System Reference Document for D&D 5E including spells, monsters, classes, equipment, and more"
           },
           {
+            "@type": "WebApplication",
+            "name": "FRC Radio",
+            "description": "On-demand background music streaming for tabletop RPG sessions with curated playlists"
+          },
+          {
             "@type": "CreativeWork",
             "name": "Free Character Sheets",
             "description": "Printable D&D 5E character sheet PDFs in multiple formats"
@@ -94,6 +99,37 @@
           <a href="/dnd/5e/srd/contents" class="resource-link">
             <span>Browse SRD Contents</span>
           </a>
+        </div>
+      </div>
+    </article>
+    <article id="frc-radio" class="resource-article">
+      <div class="resource-image">
+        <svg viewBox="0 0 24 24" width="70" height="70" fill="var(--orange2)">
+          <path d="M12 1a2 2 0 0 0-1.4.6L7.2 5H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h3.2l3.4 3.4A2 2 0 0 0 12 23h0a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2z" opacity="0.85"/>
+          <path d="M16.5 7.5a5 5 0 0 1 0 9" stroke="var(--orange3)" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+          <path d="M19 5a8.5 8.5 0 0 1 0 14" stroke="var(--orange3)" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+        </svg>
+      </div>
+      <div class="resource-content">
+        <div class="inline-div">
+          <h2>FRC Radio</h2>
+          <small>- Music Streaming</small>
+        </div>
+        <div class="indent">
+          <p>
+            On-demand background music streaming for your tabletop sessions. Create a channel, pick a playlist, and share the listener link with your group. The DM controls the music while everyone listens in sync from any browser. Free accounts get access to the standard playlist library; Pro unlocks the full catalog.
+          </p>
+          <div style="display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px;">
+            <a href="https://radio.farreachco.com" target="_blank" rel="noopener" class="resource-link external-link">
+              <span>Open FRC Radio</span>
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3" />
+              </svg>
+            </a>
+            <a href="/radio" class="resource-link">
+              <span>Learn More</span>
+            </a>
+          </div>
         </div>
       </div>
     </article>


### PR DESCRIPTION
Adds radio.farreachco.com integration across the site: new resource entry on /resources, radio sidebar card on the dashboard, and a full /radio info page covering how the service works, playlists, hosting, listening, and pro features.