### PR TITLE
style: improve Record and Wyrld Record pages

### DIFF
--- a/public/css/features/record.css
+++ b/public/css/features/record.css
@@ -1,0 +1,245 @@
+/* ==========================================================================
+   Record Pages — View, Edit, Create
+   ========================================================================== */
+
+/* ---------- View Page Wrapper ---------- */
+
+.record-page {
+  margin-top: 60px;
+  padding: var(--space-2xl) var(--space-lg);
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ---------- Record Header ---------- */
+
+.record-header {
+  margin-bottom: var(--space-xl);
+  padding-bottom: var(--space-lg);
+  border-bottom: 1px solid var(--surface-border);
+  position: relative;
+}
+
+.record-header::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  width: 50px;
+  height: 2px;
+  background: linear-gradient(90deg, var(--orange), var(--orange2), transparent);
+  border-radius: 1px;
+}
+
+.record-header h1 {
+  font-family: YoungSerif, Georgia, serif;
+  font-size: 2rem;
+  color: var(--bright-white);
+  margin: 0 0 var(--space-md) 0;
+  line-height: 1.25;
+}
+
+/* ---------- Meta Badges ---------- */
+
+.record-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.record-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  font-size: 0.7rem;
+  font-family: YoungSerif, Georgia, serif;
+  text-transform: uppercase;
+  letter-spacing: 1.1px;
+  border-radius: 3px;
+  border: 1px solid var(--border-ornate);
+  color: var(--orange2);
+  background: rgba(165, 79, 4, 0.07);
+}
+
+.record-badge-wyrld {
+  color: var(--blue6);
+  border-color: rgba(116, 167, 215, 0.2);
+  background: rgba(116, 167, 215, 0.05);
+}
+
+.record-badge-public {
+  color: var(--green);
+  border-color: rgba(161, 190, 128, 0.22);
+  background: rgba(49, 74, 36, 0.25);
+}
+
+/* ---------- Description ---------- */
+
+.record-body {
+  background: linear-gradient(150deg, var(--blue3) 0%, rgba(43, 64, 83, 0.45) 100%);
+  border: 1px solid var(--surface-border);
+  border-left: 3px solid var(--border-ornate);
+  border-radius: var(--border-radius-lg);
+  padding: var(--space-xl) var(--space-2xl);
+  margin-bottom: var(--space-xl);
+  line-height: 1.8;
+  color: var(--main-white);
+  white-space: pre-wrap;
+}
+
+/* ---------- Images Grid ---------- */
+
+.record-images {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: var(--space-md);
+  margin-bottom: var(--space-xl);
+}
+
+.record-image-thumb {
+  aspect-ratio: 1;
+  width: 100%;
+  object-fit: cover;
+  display: block;
+  border-radius: var(--border-radius-lg);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-md);
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.record-image-thumb:hover {
+  border-color: var(--border-ornate-hover);
+  box-shadow: var(--shadow-warm-md);
+  transform: scale(1.03);
+}
+
+/* ---------- Actions (Edit Link) ---------- */
+
+.record-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--surface-border);
+}
+
+.record-edit-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 16px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--link-blue);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--border-radius);
+  background: rgba(116, 167, 215, 0.04);
+  text-decoration: none;
+  letter-spacing: 0.2px;
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.record-edit-link:hover {
+  color: var(--orange3);
+  background: rgba(222, 199, 174, 0.06);
+  border-color: var(--border-ornate-hover);
+}
+
+/* ==========================================================================
+   Edit & Create Pages — shared form layout
+   ========================================================================== */
+
+/* Edit page uses page-form; extend heading style for both */
+
+.record-form-title {
+  font-family: YoungSerif, Georgia, serif;
+  font-size: 1.65rem;
+  color: var(--bright-white);
+  margin: 0 0 4px 0;
+}
+
+.record-form-subtitle {
+  display: block;
+  margin-bottom: var(--space-2xl);
+}
+
+/* ---------- Existing Image List (edit page) ---------- */
+
+.record-edit-images {
+  margin: var(--space-lg) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.record-image-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-md);
+  padding: var(--space-sm);
+  background: rgba(31, 37, 49, 0.5);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--border-radius);
+}
+
+.record-image-item img {
+  max-height: 80px;
+  max-width: 120px;
+  object-fit: cover;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--surface-border);
+  display: block;
+  flex-shrink: 0;
+}
+
+.record-remove-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(120, 51, 51, 0.25);
+  border: 1px solid rgba(206, 101, 101, 0.2);
+  color: var(--red3);
+  cursor: pointer;
+  font-size: 0.85rem;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 2px;
+  text-decoration: none;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.record-remove-btn:hover {
+  background: rgba(120, 51, 51, 0.5);
+  border-color: rgba(241, 143, 143, 0.35);
+  color: var(--red3);
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 640px) {
+  .record-page {
+    padding: var(--space-xl) var(--space-md);
+  }
+
+  .record-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .record-body {
+    padding: var(--space-md) var(--space-lg);
+  }
+}

--- a/views/editrecord.ejs
+++ b/views/editrecord.ejs
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Far Reach Co. | Edit <%= record.title %></title>
   <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/css/features/record.css" />
   <%- include('./partials/icons') %>
   <script src="/lib/MobileNavHandler.js" defer></script>
   <script src="/lib/htmx.min.js"></script>
@@ -15,55 +16,63 @@
 
 <body>
   <%- include('./partials/nav') %>
-  <div class="container-fluid info-container p-3">
-    <div>
-      <h1>Edit <%= record.title %></h1>
-      <small>- Record</small>
-    </div>
-    <br />
-    <div class="input-container">
-      <label for="title">Title</label>
-      <input id="title" name="title" placeholder="Record Title" value="<%= record.title %>" />
-    </div>
-    <br />
-    <div class="input-container w-100">
-      <label for="description">Description</label>
-      <textarea class="w-100" id="description" name="description" required><%= record.description %></textarea>
-    </div>
-    <div id="images-list">
-      <% if (imageUrls && Object.keys(imageUrls).length) { %>
-      <% Object.entries(imageUrls).forEach(([key, value]) => { %>
-      <div class="d-flex align-items-baseline">
-        <img class="my-2 max-w-90" id="img-<%= key %>" src="<%= value %>">
-        <div class="text-red ms-2 cursor-pointer red-x" title="Remove image" data-remove-image="<%= key %>">ⓧ</div>
+  <div class="container-fluid info-container page-form p-3">
+
+    <h1 class="record-form-title">Edit <%= record.title %></h1>
+    <span class="record-badge record-form-subtitle">Record</span>
+
+    <fieldset>
+      <div class="input-container">
+        <label for="title">Title</label>
+        <input id="title" name="title" placeholder="Record Title" value="<%= record.title %>" />
       </div>
-      <% }) %>
+
+      <div class="input-container">
+        <label for="description">Description</label>
+        <textarea class="w-100" id="description" name="description" required><%= record.description %></textarea>
+      </div>
+
+      <% if (imageUrls && Object.keys(imageUrls).length) { %>
+      <div class="form-section">
+        <small><b class="text-orange">Attached Images</b></small>
+        <div class="record-edit-images" id="images-list">
+          <% Object.entries(imageUrls).forEach(([key, value]) => { %>
+          <div class="record-image-item">
+            <img id="img-<%= key %>" src="<%= value %>" alt="">
+            <span class="record-remove-btn" title="Remove image" data-remove-image="<%= key %>">✕</span>
+          </div>
+          <% }) %>
+        </div>
+      </div>
+      <% } else { %>
+      <div id="images-list"></div>
       <% } %>
-    </div>
-    <br />
-    <div class=" w-25">
-      <small><b class="text-orange">Upload Images</b></small>
-      <br />
-      <small class="hint">*These will also be available for use on your tables</small>
-      <br />
-      <input id="image" name="image" type="file" accept="image/*" style="display: none" multiple>
-      <label for="image" class="label-btn" title="Upload Image">Choose Images</label>
-      <div class="d-flex flex-column" id="files-list"></div>
-    </div>
-    <br />
-    <div class="w-25">
-      <small><b class="text-orange">Make Public</b></small>
-      <br />
-      <small class="hint">*Allow this page to viewed by others.</small>
-      <input type="checkbox" id="is_public" name="is_public" <%= record.is_public ? 'checked' : '' %> />
-    </div>
-    <br />
-    <br />
-    <button id="save">Save</button>
-    <hr>
-    <button class="btn-red" hx-delete="/api/remove_record/<%= record.id %>" hx-swap="none" hx-confirm="Are you sure you want to delete <%= record.title %>?">
-      Delete Record
-    </button>
+
+      <div class="form-section">
+        <small><b class="text-orange">Upload Images</b></small>
+        <small class="hint">*These will also be available for use on your tables</small>
+        <input id="image" name="image" type="file" accept="image/*" style="display: none" multiple>
+        <label for="image" class="label-btn mt-2" title="Upload Image">Choose Images</label>
+        <div class="d-flex flex-column mt-1" id="files-list"></div>
+      </div>
+
+      <div class="form-section">
+        <div class="d-flex align-items-center gap-2">
+          <input id="is_public" type="checkbox" name="is_public" <%= record.is_public ? 'checked' : '' %> />
+          <div>
+            <small><b class="text-orange">Make Public</b></small>
+            <small class="hint">*Allow this page to be viewed by others.</small>
+          </div>
+        </div>
+      </div>
+
+      <button id="save">Save</button>
+      <hr style="margin: var(--space-xl) 0; border: none; height: 1px; background: linear-gradient(90deg, transparent, var(--blue), transparent);" />
+      <button class="btn-red" hx-delete="/api/remove_record/<%= record.id %>" hx-swap="none" hx-confirm="Are you sure you want to delete <%= record.title %>?">
+        Delete Record
+      </button>
+    </fieldset>
+
   </div>
 </body>
 

--- a/views/newrecord.ejs
+++ b/views/newrecord.ejs
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Far Reach Co. | Create Record</title>
   <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/css/features/record.css" />
   <%- include('./partials/icons') %>
   <script src="/lib/MobileNavHandler.js" defer></script>
   <script src="/lib/htmx.min.js"></script>
@@ -16,7 +17,7 @@
 <body>
   <%- include('./partials/nav') %>
   <div class="container-fluid info-container page-form p-3">
-    <h1>Create Record</h1>
+    <h1 class="record-form-title">Create Record</h1>
 
     <fieldset>
       <div class="input-container">

--- a/views/newwyrldrecord.ejs
+++ b/views/newwyrldrecord.ejs
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Far Reach Co. | Create Wyrld Record</title>
   <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/css/features/record.css" />
   <%- include('./partials/icons') %>
   <script src="/lib/MobileNavHandler.js" defer></script>
   <script src="/lib/htmx.min.js"></script>
@@ -16,7 +17,7 @@
 <body>
   <%- include('./partials/nav') %>
   <div class="container-fluid info-container page-form p-3">
-    <h1>Create Wyrld Record</h1>
+    <h1 class="record-form-title">Create Wyrld Record</h1>
 
     <fieldset>
       <div class="input-container">

--- a/views/record.ejs
+++ b/views/record.ejs
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Far Reach Co. | <%= record.title %></title>
   <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/css/features/record.css" />
   <%- include('./partials/icons') %>
   <script src="/lib/MobileNavHandler.js" defer></script>
   <script src="/lib/htmx.min.js"></script>
@@ -15,34 +16,54 @@
 
 <body>
   <%- include('./partials/nav') %>
-  <div class="container-fluid info-container p-3">
-    <div>
+  <div class="container-fluid record-page">
+
+    <div class="record-header">
       <h1><%= record.title %></h1>
-      <% if (projectId) { %>
-      <small>- Wyrld Record</small>
-      <% } else { %>
-      <small>- Record</small>
-      <% } %>
-      <% if (record.is_public) { %>
-      <small>(Public)</small>
-      <% } %>
+      <div class="record-meta">
+        <% if (projectId) { %>
+        <span class="record-badge record-badge-wyrld">Wyrld Record</span>
+        <% } else { %>
+        <span class="record-badge">Record</span>
+        <% } %>
+        <% if (record.is_public) { %>
+        <span class="record-badge record-badge-public">Public</span>
+        <% } %>
+      </div>
     </div>
-    <p id="description" class="whitespace-pre-wrap"></p>
-    <div>
-      <% if (imageUrls && Object.keys(imageUrls).length) { %>
+
+    <div class="record-body" id="description"></div>
+
+    <% if (imageUrls && Object.keys(imageUrls).length) { %>
+    <div class="record-images">
       <% Object.entries(imageUrls).forEach(([key, value]) => { %>
-      <img class="my-2 max-w-90" id="img-<%= key %>" src="<%= value %>">
+      <img class="record-image-thumb" id="img-<%= key %>" src="<%= value %>" alt="" data-lightbox="<%= value %>">
       <% }) %>
+    </div>
+    <% } %>
+
+    <% if (canEdit) { %>
+    <div class="record-actions">
+      <% if (projectId) { %>
+      <a class="record-edit-link" href="/editrecord?id=<%= record.id %>&project_id=<%= projectId %>">Edit Record</a>
+      <% } else { %>
+      <a class="record-edit-link" href="/editrecord?id=<%= record.id %>">Edit Record</a>
       <% } %>
     </div>
-    <hr />
-    <% if (canEdit) { %>
-    <% if (projectId) { %>
-    <small><a href="/editrecord?id=<%= record.id %>&project_id=<%= projectId %>">Edit Record</a></small>
-    <% } else { %>
-    <small><a href="/editrecord?id=<%= record.id %>">Edit Record</a></small>
     <% } %>
-    <% } %>
+
+  </div>
+
+  <!-- Image lightbox -->
+  <div class="modal-custom" id="record-lightbox" role="dialog" aria-modal="true">
+    <div class="modal-custom-container">
+      <span class="close-custom-modal" id="lightbox-close" title="Close">&times;</span>
+      <div class="modal-custom-content">
+        <img class="modal-custom-image" id="lightbox-img" src="" alt="">
+      </div>
+    </div>
+  </div>
+
 </body>
 <script type="application/json" id="description-data"><%- JSON.stringify(record.description) %></script>
 <script type="module" defer>
@@ -53,6 +74,30 @@
   for (const elem of elems) {
     descElem.appendChild(elem);
   }
+
+  // Lightbox
+  const lightbox = document.getElementById("record-lightbox");
+  const lightboxImg = document.getElementById("lightbox-img");
+
+  document.querySelectorAll("[data-lightbox]").forEach(img => {
+    img.addEventListener("click", () => {
+      lightboxImg.src = img.dataset.lightbox;
+      lightbox.classList.add("visible");
+    });
+  });
+
+  function closeLightbox() {
+    lightbox.classList.remove("visible");
+    lightboxImg.src = "";
+  }
+
+  document.getElementById("lightbox-close").addEventListener("click", closeLightbox);
+  lightbox.addEventListener("click", e => {
+    if (e.target === lightbox) closeLightbox();
+  });
+  document.addEventListener("keydown", e => {
+    if (e.key === "Escape") closeLightbox();
+  });
 </script>
 
 </html>


### PR DESCRIPTION
## Summary
- New `record.css` feature stylesheet covering all record pages
- `record.ejs`: redesigned view with YoungSerif heading, type/visibility badges, frosted description panel, uniform square image grid with click-to-expand lightbox (backdrop click + Escape to close)
- `editrecord.ejs`: migrated to `page-form` pattern, removed `<br>` spacers, `form-section` groupings, styled image list with remove buttons
- `newrecord.ejs` / `newwyrldrecord.ejs`: added `record.css` import and `record-form-title` heading style

## Test plan
- [ ] View a record — check heading, badges, description panel, image grid
- [ ] Click an image thumbnail — lightbox opens full size; close via ×, backdrop click, and Escape key
- [ ] Edit a record — verify page-form layout, image list, upload/public sections, save/delete
- [ ] Create a new user record and a new wyrld record — verify heading style

🤖 Generated with [Claude Code](https://claude.com/claude-code)