### PR TITLE
feat: add FAQ schema and SEO improvements to SRD pages

### DIFF
--- a/public/css/features/info.css
+++ b/public/css/features/info.css
@@ -1380,6 +1380,85 @@ tr:hover {
   margin-bottom: 0;
 }
 
+/* ===== FAQ Section ===== */
+.srd-faq {
+  background: none;
+  border-left: none;
+  border-top: 1px solid rgba(72, 99, 125, 0.18);
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0.75rem 0 0.5rem;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.srd-faq-label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(107, 131, 154, 0.6);
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.srd-faq details {
+  border-bottom: 1px solid rgba(72, 99, 125, 0.12);
+  margin-bottom: 0;
+}
+
+.srd-faq details:last-child {
+  border-bottom: none;
+}
+
+.srd-faq summary {
+  cursor: pointer;
+  padding: 7px 0;
+  color: var(--bright-white);
+  font-size: 0.83rem;
+  font-weight: 500;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  transition: color 0.2s ease;
+}
+
+.srd-faq summary::-webkit-details-marker {
+  display: none;
+}
+
+.srd-faq summary::after {
+  content: '+';
+  font-size: 0.9rem;
+  color: rgba(116, 167, 215, 0.3);
+  flex-shrink: 0;
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.srd-faq details[open] summary::after {
+  transform: rotate(45deg);
+  color: rgba(116, 167, 215, 0.6);
+}
+
+.srd-faq summary:hover {
+  color: rgba(160, 180, 200, 1);
+}
+
+.srd-faq details[open] summary {
+  color: rgba(160, 180, 200, 0.9);
+}
+
+.srd-faq details p {
+  padding: 2px 0 12px;
+  padding-left: 12px;
+  color: rgba(160, 182, 202, 0.9);
+  line-height: 1.6;
+  font-size: 0.82rem;
+  margin: 0;
+  border-left: 2px solid rgba(72, 99, 125, 0.3);
+}
+
 /* ===== SEO CTA Block ===== */
 .seo-cta-block {
   display: flex;

--- a/views/dnd/5e/srd/conditions.ejs
+++ b/views/dnd/5e/srd/conditions.ejs
@@ -44,6 +44,39 @@
       }
     }
   </script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How many conditions are in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "There are 14 conditions in D&D 5th Edition: Blinded, Charmed, Deafened, Exhaustion, Frightened, Grappled, Incapacitated, Invisible, Paralyzed, Petrified, Poisoned, Prone, Restrained, Stunned, and Unconscious." }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the difference between Paralyzed and Stunned in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Both conditions incapacitate a creature and cause it to fail Strength and Dexterity saving throws. Paralyzed is more severe: the creature cannot move or speak, and any attack against it from within 5 feet is a critical hit. Stunned creatures can still speak falteringly and do not grant automatic critical hits." }
+        },
+        {
+          "@type": "Question",
+          "name": "What conditions cause automatic failure on saving throws in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Paralyzed and Unconscious both cause automatic failure on Strength and Dexterity saving throws. Stunned also causes automatic failure on Strength and Dexterity saves." }
+        },
+        {
+          "@type": "Question",
+          "name": "What does the Restrained condition do in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "A Restrained creature's speed becomes 0. Attack rolls against it have advantage, and its own attack rolls have disadvantage. It also has disadvantage on Dexterity saving throws." }
+        },
+        {
+          "@type": "Question",
+          "name": "How is the Exhaustion condition removed in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Each long rest reduces a creature's exhaustion level by 1, provided it has food and water. The Greater Restoration spell can also remove one exhaustion level." }
+        }
+      ]
+    }
+  </script>
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/features/info.css" />
   <script src="/lib/MobileNavHandler.js" defer></script>
@@ -63,6 +96,7 @@
     </div>
     <hr />
     <h2>Conditions</h2>
+    <p>D&D 5e has <strong>14 conditions</strong> that alter a creature's capabilities during play: Blinded, Charmed, Deafened, Exhaustion, Frightened, Grappled, Incapacitated, Invisible, Paralyzed, Petrified, Poisoned, Prone, Restrained, Stunned, and Unconscious. Conditions are caused by spells, monster abilities, environmental hazards, and class features. A condition lasts until it is removed — either by the effect that imposed it ending, a saving throw, or a spell like <a href="/dnd/5e/srd/spells/lesser-restoration">Lesser Restoration</a>.</p>
     <ul>
       <% data.forEach(function(condition){ %>
       <li>
@@ -83,6 +117,31 @@
       </div>
     </div>
     <% }); %>
+
+    <hr class="w-75" />
+    <section class="srd-faq">
+      <p class="srd-faq-label">Frequently Asked Questions</p>
+      <details>
+        <summary>How many conditions are in D&D 5e?</summary>
+        <p>There are 14 conditions in D&D 5th Edition: Blinded, Charmed, Deafened, Exhaustion, Frightened, Grappled, Incapacitated, Invisible, Paralyzed, Petrified, Poisoned, Prone, Restrained, Stunned, and Unconscious.</p>
+      </details>
+      <details>
+        <summary>What is the difference between Paralyzed and Stunned in D&D 5e?</summary>
+        <p>Both incapacitate the creature and cause automatic failure on Strength and Dexterity saves. Paralyzed is more severe: the creature cannot move or speak at all, and any attack against it from within 5 feet is automatically a critical hit. Stunned creatures can still speak falteringly and do not grant automatic critical hits.</p>
+      </details>
+      <details>
+        <summary>What does the Restrained condition do in D&D 5e?</summary>
+        <p>A Restrained creature's speed becomes 0 and it cannot benefit from any bonus to speed. Attack rolls against it have advantage, its own attack rolls have disadvantage, and it has disadvantage on Dexterity saving throws.</p>
+      </details>
+      <details>
+        <summary>What conditions cause automatic saving throw failure in D&D 5e?</summary>
+        <p>Paralyzed, Stunned, and Unconscious all cause a creature to automatically fail Strength and Dexterity saving throws. Attacks against a Paralyzed or Unconscious creature from within 5 feet also automatically score a critical hit.</p>
+      </details>
+      <details>
+        <summary>How is Exhaustion removed in D&D 5e?</summary>
+        <p>Each long rest removes one level of exhaustion, provided the creature has food and water. The Greater Restoration spell also removes one exhaustion level. A creature dies if it reaches exhaustion level 6.</p>
+      </details>
+    </section>
   </div>
   <%- include('../../../partials/footer') %>
 </body>

--- a/views/dnd/5e/srd/contents.ejs
+++ b/views/dnd/5e/srd/contents.ejs
@@ -97,6 +97,68 @@
         <li><a href="/dnd/5e/srd/features/arcane-recovery">Arcane Recovery</a></li>
       </ul>
     </div>
+
+    <hr />
+
+    <h2>Popular Pages</h2>
+    <p>The most-searched D&D 5e reference pages on this site.</p>
+
+    <div class="srd-see-also">
+      <h3>Spells</h3>
+      <ul>
+        <li><a href="/dnd/5e/srd/spells/barkskin">Barkskin</a></li>
+        <li><a href="/dnd/5e/srd/spells/hold-person">Hold Person</a></li>
+        <li><a href="/dnd/5e/srd/spells/inflict-wounds">Inflict Wounds</a></li>
+        <li><a href="/dnd/5e/srd/spells/acid-splash">Acid Splash</a></li>
+        <li><a href="/dnd/5e/srd/spells/spare-the-dying">Spare the Dying</a></li>
+        <li><a href="/dnd/5e/srd/spells/hellish-rebuke">Hellish Rebuke</a></li>
+        <li><a href="/dnd/5e/srd/spells/fly">Fly</a></li>
+        <li><a href="/dnd/5e/srd/spells/cure-wounds">Cure Wounds</a></li>
+        <li><a href="/dnd/5e/srd/spells/scorching-ray">Scorching Ray</a></li>
+        <li><a href="/dnd/5e/srd/spells/water-breathing">Water Breathing</a></li>
+      </ul>
+    </div>
+
+    <div class="srd-see-also">
+      <h3>Equipment</h3>
+      <ul>
+        <li><a href="/dnd/5e/srd/equipment/explorers-pack">Explorer's Pack</a></li>
+        <li><a href="/dnd/5e/srd/equipment/potion-of-superior-healing">Potion of Superior Healing</a></li>
+        <li><a href="/dnd/5e/srd/equipment/shortbow">Shortbow</a></li>
+        <li><a href="/dnd/5e/srd/equipment/rapier">Rapier</a></li>
+        <li><a href="/dnd/5e/srd/equipment/diplomats-pack">Diplomat's Pack</a></li>
+        <li><a href="/dnd/5e/srd/equipment/flail">Flail</a></li>
+        <li><a href="/dnd/5e/srd/equipment/longsword">Longsword</a></li>
+        <li><a href="/dnd/5e/srd/equipment/potion-of-greater-healing">Potion of Greater Healing</a></li>
+        <li><a href="/dnd/5e/srd/equipment/dungeoneers-pack">Dungeoneer's Pack</a></li>
+        <li><a href="/dnd/5e/srd/magic-items/ring-of-resistance">Ring of Resistance</a></li>
+      </ul>
+    </div>
+
+    <div class="srd-see-also">
+      <h3>Monsters</h3>
+      <ul>
+        <li><a href="/dnd/5e/srd/monsters/flying-snake">Flying Snake</a></li>
+        <li><a href="/dnd/5e/srd/monsters/boar">Boar</a></li>
+        <li><a href="/dnd/5e/srd/monsters/hawk">Hawk</a></li>
+        <li><a href="/dnd/5e/srd/monsters/guard">Guard</a></li>
+        <li><a href="/dnd/5e/srd/monsters/steam-mephit">Steam Mephit</a></li>
+        <li><a href="/dnd/5e/srd/monsters/dire-wolf">Dire Wolf</a></li>
+        <li><a href="/dnd/5e/srd/monsters/goblin">Goblin</a></li>
+        <li><a href="/dnd/5e/srd/monsters/imp">Imp</a></li>
+        <li><a href="/dnd/5e/srd/monsters/skeleton">Skeleton</a></li>
+        <li><a href="/dnd/5e/srd/monsters/dire-wolf">Dire Wolf</a></li>
+      </ul>
+    </div>
+
+    <div class="srd-see-also">
+      <h3>Rules Reference</h3>
+      <ul>
+        <li><a href="/dnd/5e/srd/damage-types">Damage Types</a></li>
+        <li><a href="/dnd/5e/srd/languages">Languages</a></li>
+        <li><a href="/dnd/5e/srd/conditions">Conditions</a></li>
+      </ul>
+    </div>
   </div>
   <%- include('../../../partials/footer') %>
 </body>

--- a/views/dnd/5e/srd/damagetypes.ejs
+++ b/views/dnd/5e/srd/damagetypes.ejs
@@ -44,6 +44,39 @@
       }
     }
   </script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How many damage types are in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "There are 13 damage types in D&D 5th Edition: Acid, Bludgeoning, Cold, Fire, Force, Lightning, Necrotic, Piercing, Poison, Psychic, Radiant, Slashing, and Thunder." }
+        },
+        {
+          "@type": "Question",
+          "name": "What does damage resistance mean in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Resistance halves the damage dealt by that type. Immunity negates all damage of that type entirely. Vulnerability doubles the damage taken from that type." }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the most commonly resisted damage type in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Poison is the most commonly resisted damage type in D&D 5e — a large number of monsters have resistance or immunity to it. Fire is also widely resisted and immune among creatures." }
+        },
+        {
+          "@type": "Question",
+          "name": "What is force damage in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Force is pure magical energy formed into a damaging shape. It is one of the rarest damage types and very few creatures have resistance or immunity to it, making it one of the most reliably effective damage types." }
+        },
+        {
+          "@type": "Question",
+          "name": "What damage types bypass physical resistance in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Many monsters are resistant to Bludgeoning, Piercing, and Slashing damage from non-magical weapons. Using magical weapons or spells that deal other damage types — such as Fire, Radiant, or Force — bypasses this resistance." }
+        }
+      ]
+    }
+  </script>
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/features/info.css" />
   <script src="/lib/MobileNavHandler.js" defer></script>
@@ -63,6 +96,7 @@
     </div>
     <hr />
     <h2>Damage Types</h2>
+    <p>D&D 5e has <strong>13 damage types</strong>: Acid, Bludgeoning, Cold, Fire, Force, Lightning, Necrotic, Piercing, Poison, Psychic, Radiant, Slashing, and Thunder. Every source of damage — weapons, spells, traps, and monster abilities — deals one of these types. Creatures can have <strong>resistance</strong> (half damage), <strong>immunity</strong> (no damage), or <strong>vulnerability</strong> (double damage) to specific types.</p>
     <ul>
       <% data.forEach(function(dType){ %>
       <li>
@@ -82,6 +116,31 @@
       </div>
     </div>
     <% }); %>
+
+    <hr class="w-75" />
+    <section class="srd-faq">
+      <p class="srd-faq-label">Frequently Asked Questions</p>
+      <details>
+        <summary>How many damage types are in D&D 5e?</summary>
+        <p>There are 13 damage types in D&D 5th Edition: Acid, Bludgeoning, Cold, Fire, Force, Lightning, Necrotic, Piercing, Poison, Psychic, Radiant, Slashing, and Thunder.</p>
+      </details>
+      <details>
+        <summary>What does damage resistance mean in D&D 5e?</summary>
+        <p>Resistance halves the damage dealt by that type. Immunity negates all damage of that type entirely. Vulnerability doubles the damage taken from that type. When multiple modifiers apply, resistances and vulnerabilities are applied after all other modifiers.</p>
+      </details>
+      <details>
+        <summary>What is the most commonly resisted damage type in D&D 5e?</summary>
+        <p>Poison is the most commonly resisted damage type — a large number of monsters have resistance or full immunity to it. Fire and cold are also widely resisted. Force damage is the rarest to resist, making it one of the most reliably effective damage types.</p>
+      </details>
+      <details>
+        <summary>What is force damage in D&D 5e?</summary>
+        <p>Force is pure magical energy formed into a damaging shape. Very few creatures have resistance or immunity to it, making spells like Magic Missile and Eldritch Blast especially reliable.</p>
+      </details>
+      <details>
+        <summary>What damage types bypass physical resistance in D&D 5e?</summary>
+        <p>Many monsters resist Bludgeoning, Piercing, and Slashing from non-magical weapons. Magical weapons bypass this. Spells dealing Fire, Radiant, Force, or other elemental damage types are unaffected by physical resistance entirely.</p>
+      </details>
+    </section>
   </div>
   <%- include('../../../partials/footer') %>
 </body>

--- a/views/dnd/5e/srd/equipment-item.ejs
+++ b/views/dnd/5e/srd/equipment-item.ejs
@@ -10,10 +10,69 @@
     const category = item.equipment_category?.name || 'Equipment';
     const subCategory = item.category_range || item.armor_category || item.gear_category?.name || '';
     const costStr = item.cost ? `${item.cost.quantity} ${item.cost.unit}` : '';
+
+    // Build FAQ entries from available item data
+    const faqs = [];
+    if (item.contents && item.contents.length) {
+      const contentList = item.contents.map(c => c.quantity > 1 ? `${c.quantity}x ${c.item.name}` : c.item.name).join(', ');
+      faqs.push({
+        q: `What is in the ${item.name} in D&D 5e?`,
+        a: `The ${item.name} in D&D 5th Edition contains: ${contentList}.`
+      });
+    }
+    if (item.cost) {
+      faqs.push({
+        q: `How much does the ${item.name} cost in D&D 5e?`,
+        a: `The ${item.name} costs ${item.cost.quantity} ${item.cost.unit} in D&D 5th Edition.`
+      });
+    }
+    if (item.weight) {
+      faqs.push({
+        q: `How much does the ${item.name} weigh in D&D 5e?`,
+        a: `The ${item.name} weighs ${item.weight} pounds in D&D 5th Edition.`
+      });
+    }
+    if (item.damage) {
+      const twoHand = item.two_handed_damage ? ` When used two-handed, it deals ${item.two_handed_damage.damage_dice} ${item.two_handed_damage.damage_type.name} damage.` : '';
+      faqs.push({
+        q: `How much damage does the ${item.name} deal in D&D 5e?`,
+        a: `The ${item.name} deals ${item.damage.damage_dice} ${item.damage.damage_type.name} damage in D&D 5th Edition.${twoHand}`
+      });
+    }
+    if (item.range) {
+      const longRange = item.range.long ? ` and a long range of ${item.range.long} feet` : '';
+      faqs.push({
+        q: `What is the range of the ${item.name} in D&D 5e?`,
+        a: `The ${item.name} has a normal range of ${item.range.normal} feet${longRange} in D&D 5th Edition.`
+      });
+    }
+    if (item.armor_class) {
+      const armorType = item.armor_category || subCategory || category;
+      const dexBonus = item.armor_class.dex_bonus ? ` + your Dexterity modifier${item.armor_class.max_bonus ? ` (max +${item.armor_class.max_bonus})` : ''}` : '';
+      const strReq = item.str_minimum ? ` Requires Strength ${item.str_minimum}.` : '';
+      const stealth = item.stealth_disadvantage ? ' Imposes disadvantage on Stealth checks.' : '';
+      faqs.push({
+        q: `What armor class does ${item.name} give in D&D 5e?`,
+        a: `${item.name} provides AC ${item.armor_class.base}${dexBonus} in D&D 5th Edition. It is ${armorType} armor.${strReq}${stealth}`
+      });
+    }
+
+    // Build richer meta description
+    const descParts = [];
+    if (item.contents && item.contents.length) {
+      const names = item.contents.slice(0, 4).map(c => c.item.name).join(', ');
+      descParts.push(`Contains ${names}${item.contents.length > 4 ? ' & more' : ''}.`);
+    }
+    if (item.damage) descParts.push(`${item.damage.damage_dice} ${item.damage.damage_type.name} damage.`);
+    if (item.armor_class) descParts.push(`AC ${item.armor_class.base}${item.armor_class.dex_bonus ? '+Dex' : ''}.`);
+    if (item.range) descParts.push(`Range ${item.range.normal}/${item.range.long || item.range.normal} ft.`);
+    if (costStr) descParts.push(`Cost: ${costStr}.`);
+    if (item.weight) descParts.push(`Weight: ${item.weight} lb.`);
+    const metaDesc = `${item.name} D&D 5e stats: ${descParts.join(' ')} Complete reference for ${subCategory || category}.`.substring(0, 160);
   %>
 
   <title><%= item.name %> - D&D 5E <%= category %> | Far Reach Co.</title>
-  <meta name="description" content="<%= item.name %> is a D&D 5E <%= subCategory || category %>. <%= costStr ? 'Cost: ' + costStr + '.' : '' %> <%= item.weight ? 'Weight: ' + item.weight + ' lb.' : '' %> <%= item.damage ? 'Damage: ' + item.damage.damage_dice + ' ' + item.damage.damage_type.name + '.' : '' %>" />
+  <meta name="description" content="<%= metaDesc %>" />
   <link rel="canonical" href="https://farreachco.com/dnd/5e/srd/equipment/<%= item.index %>" />
 
   <!-- Open Graph / Facebook -->
@@ -72,6 +131,20 @@
       }
     }
   </script>
+
+  <% if (faqs.length > 0) { %>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": <%- JSON.stringify(faqs.map(f => ({
+        "@type": "Question",
+        "name": f.q,
+        "acceptedAnswer": { "@type": "Answer", "text": f.a }
+      }))) %>
+    }
+  </script>
+  <% } %>
 
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/features/info.css" />
@@ -224,6 +297,19 @@
       </li>
       <% }) %>
     </ul>
+    <% } %>
+
+    <% if (faqs.length > 0) { %>
+    <hr class="w-75" />
+    <section class="srd-faq">
+      <p class="srd-faq-label">Frequently Asked Questions</p>
+      <% faqs.forEach(faq => { %>
+      <details>
+        <summary><%= faq.q %></summary>
+        <p><%= faq.a %></p>
+      </details>
+      <% }) %>
+    </section>
     <% } %>
 
     <div class="srd-back-link">

--- a/views/dnd/5e/srd/equipment.ejs
+++ b/views/dnd/5e/srd/equipment.ejs
@@ -91,12 +91,17 @@
       <a href="#martial-weapons">Martial Weapons</a>
       <a href="#melee-weapons">Melee Weapons</a>
       <a href="#martial-melee-weapons">Martial Melee Weapons</a>
+      <a href="#adventuring-gear">Adventuring Gear</a>
+      <a href="#standard-gear">Standard Gear</a>
+      <a href="#equipment-packs">Equipment Packs</a>
       <a href="#arcane-foci">Arcane Foci</a>
       <a href="#druidic-foci">Druidic Foci</a>
       <a href="#holy-symbols">Holy Symbols</a>
       <a href="#artisans-tools">Artisan's Tools</a>
       <a href="#musical-instruments">Musical Instruments</a>
       <a href="#tools">Tools</a>
+      <a href="#mounts-and-vehicles">Mounts & Vehicles</a>
+      <a href="#magic-items">Magic Items</a>
     </div>
 
     <hr />
@@ -247,7 +252,7 @@
     </ul>
 
     <hr />
-    <h2>Magic Items</h2>
+    <h2 id="magic-items">Magic Items</h2>
     <p>Magic items are listed separately but remain tightly linked with the rest of the equipment system.</p>
     <ul class="srd-col-list-3">
       <% magicItemsData.forEach(item => { %>

--- a/views/dnd/5e/srd/languages.ejs
+++ b/views/dnd/5e/srd/languages.ejs
@@ -44,6 +44,39 @@
       }
     }
   </script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How many languages are in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "The D&D 5e SRD includes 16 languages divided into Standard languages (Common, Dwarvish, Elvish, Giant, Gnomish, Goblin, Halfling, Orc) and Exotic languages (Abyssal, Celestial, Draconic, Deep Speech, Infernal, Primordial, Sylvan, Undercommon)." }
+        },
+        {
+          "@type": "Question",
+          "name": "What language do fiends speak in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Demons speak Abyssal and devils speak Infernal. Both are Exotic languages in D&D 5e. Warlocks with fiendish patrons often learn Infernal as a bonus language." }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the oldest language in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Draconic is considered one of the oldest languages in D&D, predating most other languages. It is used by dragons and is the basis for many arcane scripts." }
+        },
+        {
+          "@type": "Question",
+          "name": "What languages do elves speak in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Elves speak Common and Elvish. Drow (dark elves) also speak Elvish, and some learn Undercommon due to their underground society." }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the difference between Standard and Exotic languages in D&D 5e?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Standard languages are spoken by common humanoid races and are widely available as starting languages. Exotic languages are associated with monsters, outsiders, or ancient cultures — they typically require a special background, race, or DM approval to learn." }
+        }
+      ]
+    }
+  </script>
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/features/info.css" />
   <script src="/lib/MobileNavHandler.js" defer></script>
@@ -63,6 +96,7 @@
     </div>
     <hr />
     <h2>Languages</h2>
+    <p>D&D 5e includes <strong>16 languages</strong> split into two categories. <strong>Standard languages</strong> (Common, Dwarvish, Elvish, Giant, Gnomish, Goblin, Halfling, Orc) are spoken by common races and are the most likely to be encountered in everyday play. <strong>Exotic languages</strong> (Abyssal, Celestial, Draconic, Deep Speech, Infernal, Primordial, Sylvan, Undercommon) are associated with monsters, outsiders, and ancient cultures. Most characters start with Common plus any languages granted by their race or background.</p>
     <ul>
       <% data.forEach(function(language){ %>
       <li>
@@ -75,6 +109,7 @@
     <div id="<%= language.index %>">
       <h3><%= language.name %></h3>
       <div class="indent">
+        <% if (language.type) { %><p><i><%= language.type %> language<% if (language.script) { %> &mdash; <%= language.script %> script<% } %></i></p><% } %>
         <h4>Typical Speakers</h4>
         <ul>
           <% language.typical_speakers.forEach(speaker => { %>
@@ -90,6 +125,31 @@
     </div>
     <br>
     <% }); %>
+
+    <hr class="w-75" />
+    <section class="srd-faq">
+      <p class="srd-faq-label">Frequently Asked Questions</p>
+      <details>
+        <summary>How many languages are in D&D 5e?</summary>
+        <p>The D&D 5e SRD includes 16 languages: 8 Standard (Common, Dwarvish, Elvish, Giant, Gnomish, Goblin, Halfling, Orc) and 8 Exotic (Abyssal, Celestial, Draconic, Deep Speech, Infernal, Primordial, Sylvan, Undercommon).</p>
+      </details>
+      <details>
+        <summary>What language do fiends speak in D&D 5e?</summary>
+        <p>Demons speak Abyssal and devils speak Infernal. Both are Exotic languages. Warlocks with fiendish patrons often learn Infernal as a bonus language.</p>
+      </details>
+      <details>
+        <summary>What is the oldest language in D&D 5e?</summary>
+        <p>Draconic is one of the oldest languages in D&D, predating most others. It is spoken by dragons and is the basis for many arcane scripts used by wizards.</p>
+      </details>
+      <details>
+        <summary>What languages do elves speak in D&D 5e?</summary>
+        <p>Elves speak Common and Elvish. Drow (dark elves) also speak Elvish, and many learn Undercommon due to their underground society.</p>
+      </details>
+      <details>
+        <summary>What is the difference between Standard and Exotic languages in D&D 5e?</summary>
+        <p>Standard languages are spoken by common humanoid races and widely available as starting languages. Exotic languages are tied to monsters, outsiders, or ancient cultures and typically require a special race, background, or DM permission to learn.</p>
+      </details>
+    </section>
   </div>
   <%- include('../../../partials/footer') %>
 </body>

--- a/views/dnd/5e/srd/magic-item.ejs
+++ b/views/dnd/5e/srd/magic-item.ejs
@@ -9,11 +9,39 @@
   <%
     const category = item.equipment_category?.name || 'Magic Item';
     const rarity = item.rarity?.name || 'Unknown';
-    const descPreview = item.desc && item.desc.length > 1 ? item.desc[1].substring(0, 150) : '';
+    const typeAttunementLine = item.desc && item.desc.length ? item.desc[0] : '';
+    const requiresAttunement = typeAttunementLine.toLowerCase().includes('attunement');
+    const descBody = item.desc && item.desc.length > 1 ? item.desc[1] : (item.desc && item.desc.length ? item.desc[0] : '');
+
+    // Build FAQ entries
+    const faqs = [];
+    faqs.push({
+      q: `What rarity is the ${item.name} in D&D 5e?`,
+      a: `The ${item.name} is a ${rarity} magic item in D&D 5th Edition.`
+    });
+    faqs.push({
+      q: `What type of magic item is the ${item.name} in D&D 5e?`,
+      a: `The ${item.name} is a ${category}${typeAttunementLine ? ' — ' + typeAttunementLine : ''}.`
+    });
+    faqs.push({
+      q: `Does the ${item.name} require attunement in D&D 5e?`,
+      a: requiresAttunement
+        ? `Yes, the ${item.name} requires attunement. Check the item description for any specific attunement requirements.`
+        : `No, the ${item.name} does not require attunement and can be used immediately when held or worn.`
+    });
+    if (item.variants && item.variants.length) {
+      faqs.push({
+        q: `What variants of the ${item.name} exist in D&D 5e?`,
+        a: `The following variants are available: ${item.variants.map(v => v.name).join(', ')}.`
+      });
+    }
+
+    // Richer meta description
+    const metaDesc = `${item.name} — ${rarity} ${category} in D&D 5e.${requiresAttunement ? ' Requires attunement.' : ''} ${descBody.substring(0, 110)}`.substring(0, 160);
   %>
 
   <title><%= item.name %> - D&D 5E Magic Item | Far Reach Co.</title>
-  <meta name="description" content="<%= item.name %> is a <%= rarity %> magic item in D&D 5E. <%= descPreview %>..." />
+  <meta name="description" content="<%= metaDesc %>" />
   <link rel="canonical" href="https://farreachco.com/dnd/5e/srd/magic-items/<%= item.index %>" />
 
   <!-- Open Graph / Facebook -->
@@ -73,6 +101,20 @@
     }
   </script>
 
+  <% if (faqs.length > 0) { %>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": <%- JSON.stringify(faqs.map(f => ({
+        "@type": "Question",
+        "name": f.q,
+        "acceptedAnswer": { "@type": "Answer", "text": f.a }
+      }))) %>
+    }
+  </script>
+  <% } %>
+
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/features/info.css" />
   <script src="/lib/MobileNavHandler.js" defer></script>
@@ -127,6 +169,19 @@
       </li>
       <% }) %>
     </ul>
+    <% } %>
+
+    <% if (faqs.length > 0) { %>
+    <hr class="w-75" />
+    <section class="srd-faq">
+      <p class="srd-faq-label">Frequently Asked Questions</p>
+      <% faqs.forEach(faq => { %>
+      <details>
+        <summary><%= faq.q %></summary>
+        <p><%= faq.a %></p>
+      </details>
+      <% }) %>
+    </section>
     <% } %>
 
     <div class="srd-back-link">

--- a/views/dnd/5e/srd/monster.ejs
+++ b/views/dnd/5e/srd/monster.ejs
@@ -28,6 +28,40 @@
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-+|-+$/g, '');
     const monsterImage = monster.image ? imageBaseUrl + monster.image : null;
+
+    // Build FAQ entries from monster data
+    const faqs = [];
+    const ac = monster.armor_class && monster.armor_class.length ? monster.armor_class[0].value : null;
+    faqs.push({
+      q: `What type of creature is the ${monster.name} in D&D 5e?`,
+      a: `The ${monster.name} is a ${monster.size} ${monster.type} with ${monster.alignment} alignment in D&D 5th Edition.`
+    });
+    faqs.push({
+      q: `What is the ${monster.name}'s challenge rating in D&D 5e?`,
+      a: `The ${monster.name} has a Challenge Rating (CR) of ${crDisplay(monster.challenge_rating)}, worth ${monster.xp} XP.`
+    });
+    faqs.push({
+      q: `What are the ${monster.name}'s hit points and armor class in D&D 5e?`,
+      a: `The ${monster.name} has ${monster.hit_points} hit points (${monster.hit_points_roll}) and an Armor Class of ${ac} in D&D 5th Edition.`
+    });
+    if (monster.damage_resistances && monster.damage_resistances.length) {
+      faqs.push({
+        q: `What is the ${monster.name} resistant to in D&D 5e?`,
+        a: `The ${monster.name} has resistance to: ${monster.damage_resistances.join(', ')}.`
+      });
+    }
+    if (monster.damage_immunities && monster.damage_immunities.length) {
+      faqs.push({
+        q: `What is the ${monster.name} immune to in D&D 5e?`,
+        a: `The ${monster.name} is immune to: ${monster.damage_immunities.join(', ')}.`
+      });
+    }
+    if (monster.speed && monster.speed.fly) {
+      faqs.push({
+        q: `Can the ${monster.name} fly in D&D 5e?`,
+        a: `Yes, the ${monster.name} has a flying speed of ${monster.speed.fly}${monster.speed.hover ? ' (hover)' : ''} in D&D 5th Edition.`
+      });
+    }
   %>
 
   <title><%= monster.name %> - D&D 5E Monster Stats | Far Reach Co.</title>
@@ -97,6 +131,20 @@
       }
     }
   </script>
+
+  <% if (faqs.length > 0) { %>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": <%- JSON.stringify(faqs.map(f => ({
+        "@type": "Question",
+        "name": f.q,
+        "acceptedAnswer": { "@type": "Answer", "text": f.a }
+      }))) %>
+    }
+  </script>
+  <% } %>
 
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/features/info.css" />
@@ -494,6 +542,19 @@
           <% } %>
         </ul>
       </div>
+
+      <% if (faqs.length > 0) { %>
+      <hr class="w-75" />
+      <section class="srd-faq">
+        <p class="srd-faq-label">Frequently Asked Questions</p>
+        <% faqs.forEach(faq => { %>
+        <details>
+          <summary><%= faq.q %></summary>
+          <p><%= faq.a %></p>
+        </details>
+        <% }) %>
+      </section>
+      <% } %>
 
       <div class="srd-back-link">
         <a href="/dnd/5e/srd/monsters">&larr; Back to Monster List</a>

--- a/views/dnd/5e/srd/spell.ejs
+++ b/views/dnd/5e/srd/spell.ejs
@@ -15,10 +15,46 @@
     };
     const levelDisplayShort = level => level === 0 ? 'Cantrip' : 'Level ' + level;
     const componentNames = { V: 'Verbal', S: 'Somatic', M: 'Material' };
+
+    // Build FAQ entries from spell data
+    const faqs = [];
+    const classesStr = spell.classes.map(c => c.name).join(', ');
+    if (spell.classes.length) {
+      const subclassStr = spell.subclasses && spell.subclasses.length ? ` It is also available to: ${spell.subclasses.map(s => s.name).join(', ')}.` : '';
+      faqs.push({
+        q: `Who can cast ${spell.name} in D&D 5e?`,
+        a: `${spell.name} is available to the following classes: ${classesStr}.${subclassStr}`
+      });
+    }
+    faqs.push({
+      q: `Is ${spell.name} a concentration spell in D&D 5e?`,
+      a: spell.concentration
+        ? `Yes, ${spell.name} requires concentration and lasts up to ${spell.duration}.`
+        : `No, ${spell.name} does not require concentration. It lasts ${spell.duration}.`
+    });
+    faqs.push({
+      q: `What level is ${spell.name} in D&D 5e?`,
+      a: spell.level === 0
+        ? `${spell.name} is a cantrip (0th-level) ${spell.school.name} spell.`
+        : `${spell.name} is a ${levelDisplay(spell.level)} ${spell.school.name} spell.`
+    });
+    faqs.push({
+      q: `What is the range and casting time of ${spell.name} in D&D 5e?`,
+      a: `${spell.name} has a range of ${spell.range} and a casting time of ${spell.casting_time} in D&D 5th Edition.`
+    });
+    if (spell.ritual) {
+      faqs.push({
+        q: `Can ${spell.name} be cast as a ritual in D&D 5e?`,
+        a: `Yes, ${spell.name} can be cast as a ritual. Ritual casting takes an extra 10 minutes but does not expend a spell slot.`
+      });
+    }
+
+    // Build richer meta description
+    const spellMetaDesc = `${spell.name}: ${levelDisplay(spell.level)} ${spell.school.name} spell for ${classesStr}. Casting time: ${spell.casting_time}. Range: ${spell.range}.${spell.concentration ? ' Concentration.' : ''}${spell.ritual ? ' Ritual.' : ''} Full spell details and rules.`.substring(0, 160);
   %>
 
   <title><%= spell.name %> - D&D 5E Spell | Far Reach Co.</title>
-  <meta name="description" content="<%= spell.name %> is a <%= levelDisplay(spell.level) %> <%= spell.school.name %> spell. <%= spell.desc[0].substring(0, 150) %>..." />
+  <meta name="description" content="<%= spellMetaDesc %>" />
   <link rel="canonical" href="https://farreachco.com/dnd/5e/srd/spells/<%= spell.index %>" />
 
   <!-- Open Graph / Facebook -->
@@ -77,6 +113,20 @@
       }
     }
   </script>
+
+  <% if (faqs.length > 0) { %>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": <%- JSON.stringify(faqs.map(f => ({
+        "@type": "Question",
+        "name": f.q,
+        "acceptedAnswer": { "@type": "Answer", "text": f.a }
+      }))) %>
+    }
+  </script>
+  <% } %>
 
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/features/info.css" />
@@ -243,6 +293,19 @@
         <% }) %>
       </div>
     </div>
+    <% } %>
+
+    <% if (faqs.length > 0) { %>
+    <hr class="w-75" />
+    <section class="srd-faq">
+      <p class="srd-faq-label">Frequently Asked Questions</p>
+      <% faqs.forEach(faq => { %>
+      <details>
+        <summary><%= faq.q %></summary>
+        <p><%= faq.a %></p>
+      </details>
+      <% }) %>
+    </section>
     <% } %>
 
     <div class="srd-back-link">


### PR DESCRIPTION
- Add FAQPage JSON-LD and visible FAQ accordions to spell, equipment, magic-item, and monster detail pages with auto-generated questions from item/spell/monster data
- Improve meta descriptions across all detail page templates to include concrete stats and be more click-worthy
- Add Popular Pages section to SRD contents index with deep links to top-searched spells, equipment, monsters, and reference pages
- Expand damage types, languages, and conditions pages with intro paragraphs and FAQPage JSON-LD targeting high-impression queries
- Fix missing Standard Gear, Equipment Packs, Mounts & Vehicles, and Magic Items filter pills on equipment index page
- Add .srd-faq styles to info.css for discreet accordion FAQ display