### PR TITLE
feat: add standard/sandbox mode toggle to table manager settings

### DIFF
--- a/public/components/table/socketEventHandlers.js
+++ b/public/components/table/socketEventHandlers.js
@@ -154,5 +154,13 @@ export function buildSocketEventHandlers(integration) {
     "reload-location-pins": () => {
       integration.tableApp?.reloadLocationPins?.();
     },
+
+    "table-mode-changed": () => {
+      const app = integration.tableApp;
+      if (!app) return;
+      const tableId = app.tableId;
+      app.teardown();
+      app.loadTable(tableId);
+    },
   };
 }

--- a/public/components/table/socketIntegration.js
+++ b/public/components/table/socketIntegration.js
@@ -130,6 +130,13 @@ class SocketIntegration {
       y,
     });
   };
+
+  tableModeChanged = (mode) => {
+    this.socket.emit("table-mode-changed", {
+      table: `table-${this.tableApp.tableId}`,
+      mode,
+    });
+  };
 }
 const socketIntegration = new SocketIntegration();
 export default socketIntegration;

--- a/public/components/table/tableSidebarSettingsModal.js
+++ b/public/components/table/tableSidebarSettingsModal.js
@@ -77,16 +77,54 @@ export async function renderTableSettingsModal(sidebar) {
             }),
       ]),
       createElement("br"),
+      createElement("div", { class: "d-flex align-items-center" }, [
+        createElement(
+          "small",
+          {
+            class: "text-orange me-1 font-bold",
+          },
+          "Sandbox Mode",
+        ),
+        sidebar.tableView.mode === "sandbox"
+          ? createElement("input", {
+              type: "checkbox",
+              name: "mode",
+              id: "mode-input",
+              checked: true,
+            })
+          : createElement("input", {
+              type: "checkbox",
+              name: "mode",
+              id: "mode-input",
+            }),
+      ]),
+      createElement("br"),
       createElement("button", { class: "new-btn me-1" }, "Save", {
         type: "click",
         event: async (e) => {
           e.preventDefault();
           const titleInput = document.getElementById("title-input");
           const isPublicInput = document.getElementById("is_public-input");
+          const modeInput = document.getElementById("mode-input");
+
+          const newMode = modeInput.checked ? "sandbox" : "standard";
+          const modeChanged = newMode !== sidebar.tableView.mode;
+
+          if (modeChanged) {
+            const confirmed = await window.customConfirm(
+              `Switch to ${newMode} mode? All connected users will be re-initialized.`,
+              { confirmText: "Switch" },
+            );
+            if (!confirmed) {
+              modeInput.checked = sidebar.tableView.mode === "sandbox";
+              return;
+            }
+          }
 
           const res = await postThing(`/api/edit_table_view/${sidebar.tableView.id}`, {
             title: titleInput.value,
             is_public: isPublicInput.checked,
+            mode: newMode,
           });
           if (res) {
             const titleUpdateMessageElem = document.querySelector(
@@ -100,6 +138,17 @@ export async function renderTableSettingsModal(sidebar) {
               titleInput.value;
             sidebar.tableView.title = titleInput.value;
             sidebar.tableView.is_public = isPublicInput.checked;
+            sidebar.tableView.mode = newMode;
+
+            if (modeChanged) {
+              socketIntegration.tableModeChanged(newMode);
+              const app = socketIntegration.tableApp;
+              if (app) {
+                const tableId = app.tableId;
+                app.teardown();
+                app.loadTable(tableId);
+              }
+            }
           }
         },
       }),

--- a/src/socket/registerTableInteractionHandlers.ts
+++ b/src/socket/registerTableInteractionHandlers.ts
@@ -185,4 +185,18 @@ export function registerTableInteractionHandlers(params: {
       socket.broadcast.to(table).emit("reload-location-pins");
     },
   );
+
+  socket.on(
+    "table-mode-changed",
+    async ({ table, mode }: { table: string; mode: string }) => {
+      const canManage = await authorizeSocketTable(
+        socket,
+        table,
+        "edit",
+        "canManageTableSettings",
+      );
+      if (!canManage) return;
+      socket.broadcast.to(table).emit("table-mode-changed", { mode });
+    },
+  );
 }


### PR DESCRIPTION
- Server socket handler validates canManageTableSettings and rebroadcasts table-mode-changed to room
- Client emitter sends table-mode-changed via socketIntegration
- Client listener reinitializes app via teardown + loadTable on mode change
- Settings modal adds Sandbox Mode toggle with confirm dialog before saving